### PR TITLE
修正：デプロイ時のキャッシュ無効化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Sync files to S3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --follow-symlinks --delete  # 公開アクセスの設定と削除オプション
+          args: --follow-symlinks --delete --cache-control "no-cache,no-store,must-revalidate" # 公開アクセスの設定と削除オプション＋キャッシュの無効化
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}  # S3バケット名をGitHub Secretsに設定
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}  # アクセスキー

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -28,7 +28,7 @@ function HomePage() {
                 <li><strong>更新</strong>：選手情報の更新（名前、背番号の変更およびクラブの移籍）ができます。</li>
             </ul>
 
-            <h2>GitHubリポジトリ（GitHub Repository）</h2>
+            <h2>GitHubリポジトリ（Repository）</h2>
             <p>下記のリンクから、このシステムのリポジトリを確認できます。</p>
             <ul>
                 <li><a href="https://github.com/AijiY/FootballStatsManagement" target='_blank'>Webアプリケーション</a></li>


### PR DESCRIPTION
開発用に、簡単にキャッシュ無効化を設定。

本番環境では下記のようにstaticとそれ以外を分けて管理するのが推奨とのこと
```
- name: Sync files to S3
  uses: jakejarvis/s3-sync-action@master
  with:
    args: --follow-symlinks --delete --exclude 'static/*' --cache-control 'no-cache,no-store,must-revalidate'
  env:
    AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
    SOURCE_DIR: './build'

- name: Sync static files to S3
  uses: jakejarvis/s3-sync-action@master
  with:
    args: --follow-symlinks --delete --include 'static/*' --cache-control 'public,max-age=31536000,immutable'
  env:
    AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
    SOURCE_DIR: './build'
```